### PR TITLE
Revert release archive flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         godot_executable_download_url: https://github.com/godotengine/godot/releases/download/4.0-stable/Godot_v4.0-stable_linux.x86_64.zip
         godot_export_templates_download_url: https://github.com/godotengine/godot/releases/download/4.0-stable/Godot_v4.0-stable_export_templates.tpz
         relative_project_path: ./game/
-        archive_output: false
+        archive_output: true
         use_godot_4: true
 
     - name: create release


### PR DESCRIPTION
Unintentionally set release to not include archived artifacts, breaking release.