### PR TITLE
Fix Issue With Modal Menu

### DIFF
--- a/game/scenes/interface/MenuModal/MenuModal.gd
+++ b/game/scenes/interface/MenuModal/MenuModal.gd
@@ -18,13 +18,17 @@ func _ready():
 	if hide_quit_on_plaform:
 		desktop_exit_button.queue_free()
 
+	hide()
+
 func pause():
+	show()
 	animation_player.play("Pause")
 	get_tree().paused = true
 	continue_button.grab_focus()
 
 func unpause():
 	animation_player.play("Unpause")
+	hide()
 	get_tree().paused = false
 
 func _unhandled_input(event: InputEvent) -> void:

--- a/game/scenes/systems/TerrainGenerator/TerrainGenerator.gd
+++ b/game/scenes/systems/TerrainGenerator/TerrainGenerator.gd
@@ -246,6 +246,8 @@ func _determine_y_value(x: int):
 	return min_y + int(normalized_noise * y_range)
 
 func redraw_terrain():
+	if not is_node_ready():
+		return
 	ground_layer.clear()
 
 	for obj in instance_dict.values():


### PR DESCRIPTION
This pull request includes changes to improve the user interface and functionality of the `MenuModal` and `TerrainGenerator` components in the game. The most important changes include hiding the menu modal on initialization, showing the menu when paused, and ensuring the terrain generator only redraws when the node is ready.

Improvements to `MenuModal`:

* [`game/scenes/interface/MenuModal/MenuModal.gd`](diffhunk://#diff-b84026604b8b97a48030dbaf174c5e8801a9087557b67800a92730b556c6d871R21-R31): Added a call to `hide()` in the `_ready()` function to ensure the menu modal is hidden on initialization.
* [`game/scenes/interface/MenuModal/MenuModal.gd`](diffhunk://#diff-b84026604b8b97a48030dbaf174c5e8801a9087557b67800a92730b556c6d871R21-R31): Modified the `pause` function to call `show()` to display the menu when the game is paused.
* [`game/scenes/interface/MenuModal/MenuModal.gd`](diffhunk://#diff-b84026604b8b97a48030dbaf174c5e8801a9087557b67800a92730b556c6d871R21-R31): Modified the `unpause` function to call `hide()` to hide the menu when the game is unpaused.

Improvements to `TerrainGenerator`:

* [`game/scenes/systems/TerrainGenerator/TerrainGenerator.gd`](diffhunk://#diff-87e3877b5d4a2a64f87ff8b574b07326ff6a7aecb4366b680b098ce8a44dec2cR249-R250): Added a check in `redraw_terrain()` to ensure the node is ready before clearing and redrawing the terrain.